### PR TITLE
PHP_MYSQL_TEMPLATEを修正

### DIFF
--- a/PHP_MYSQL_TEMPLATE/db/init.sql
+++ b/PHP_MYSQL_TEMPLATE/db/init.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE IF NOT EXISTS sampledb CHARACTER SET utf8mb4;
-USE sampledb;
+CREATE DATABASE IF NOT EXISTS chat CHARACTER SET utf8mb4;
+USE chat;
 
-CREATE TABLE article(
+CREATE TABLE blog(
     id INTEGER AUTO_INCREMENT PRIMARY KEY,
     title TEXT NOT NULL,
     content TEXT NOT NULL
@@ -13,5 +13,5 @@ CREATE TABLE user(
 );
 
 INSERT INTO blog (`id`, `title`,     `content`)  VALUES (1, '初めまして！', 'こんにちはこんにちは');
-INSERT INTO user   (`id`, `loginid`,   `password`) VALUES (1, 'guest', '$2y$10$99r270WKG.xMomYqiKr/IuCfrUCoEw2rT1Eyni2b0sfsm3LF6EN16');
-INSERT INTO user   (`id`, `loginid`,   `password`) VALUES (1855, 'admin', '$2y$10$catzjSl5wYyegRq3Mi6Y3eQJvdbAbI3M60SuKGyGjcobdnWsBnUb.');
+INSERT INTO user   (`id`, `username`,   `password`) VALUES (1, 'guest', '$2y$10$99r270WKG.xMomYqiKr/IuCfrUCoEw2rT1Eyni2b0sfsm3LF6EN16');
+INSERT INTO user   (`id`, `username`,   `password`) VALUES (1855, 'admin', '$2y$10$catzjSl5wYyegRq3Mi6Y3eQJvdbAbI3M60SuKGyGjcobdnWsBnUb.');


### PR DESCRIPTION
db/init.sql のデータベース(db)名とカラム名が統一されておらずそのままではテンプレートから起動できなかったので修正しました。